### PR TITLE
Bugfix, add missing import

### DIFF
--- a/src/ConnectionHandler.php
+++ b/src/ConnectionHandler.php
@@ -2,6 +2,7 @@
 
 namespace Epiecs\PhpMiko;
 use phpseclib3\Exception\UnableToConnectException;
+use Epiecs\PhpMiko\Devices\DeviceInterface;
 /**
 *  Connection class
 *


### PR DESCRIPTION
Custom class code always fails because it is checking the wrong class